### PR TITLE
Added dependencies and correct gem name for apipie

### DIFF
--- a/lib/generators/petergate_api/install_generator.rb
+++ b/lib/generators/petergate_api/install_generator.rb
@@ -14,7 +14,7 @@ module PetergateApi
       end
 
       def add_to_gemfile
-        gem "apipie"
+        gem "apipie-rails"
       end
 
       def insert_into_user_model

--- a/petergate_api.gemspec
+++ b/petergate_api.gemspec
@@ -21,4 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "apipie-rails", "~> 0.3.6"
+  spec.add_dependency "petergate"
 end


### PR DESCRIPTION
Added apipie-rails 0.3.6 as dependency 
Added petergate as dependency 

petergate_api install generator now adds apipie-rails to gemfile instead of apipie 
